### PR TITLE
Bugfix: simulation_type_knockdown with multiple genes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dyngen 1.0.6
+
+* BUG FIX `simulation_type_knockdown()`: Allow easier knocking down of multiple genes.
+
 # dyngen 1.0.5
 
 * MINOR CHANGE: Refactor matrix coercion thanks to Matrix 1.5-0.

--- a/R/6_simulation.R
+++ b/R/6_simulation.R
@@ -617,7 +617,7 @@ simulation_type_knockdown <- function(
       (is.list(genes) && length(genes) == num_simulations) ||
         is.character(genes) || is.factor(genes)
     )
-    if (!is.list(genes)) genes <- as.list(rep(genes, num_simulations))
+    if (!is.list(genes)) genes <- as.list(rep(list(genes), num_simulations))
     
     tibble(
       type = "knockdown",


### PR DESCRIPTION
According to the vignette, this is the way to create a knockdown simulation:

`b3_genes <- model_common$feature_info %>% filter(module_id == "B3") %>% pull(feature_id)`

`model_ko <- model_common
model_ko$simulation_params$experiment_params <- simulation_type_knockdown(
  num_simulations = 100L,
  timepoint = 0, 
  genes = b3_genes,
  num_genes = length(b3_genes),
  multiplier = 0
)`

However, when there are multiple genes associated with the module, this did not work and produced relating to incompatible sizes in `tibble()`.
This is due to the checks performed in simulation_type_knockdown.

Fixes #56 
Fixes #45 